### PR TITLE
refactor: replace misleading $quoteTransfer variable names with generic $abstractTransfer to reflect abstract transfer usage

### DIFF
--- a/contribution-license-agreement.txt
+++ b/contribution-license-agreement.txt
@@ -1,0 +1,1 @@
+I hereby agree to Spryker\'s Contribution License Agreement in https://github.com/spryker/step-engine/blob/389fc9bff404760d300e50c4b31aaab40c7e9379/CONTRIBUTING.md.

--- a/src/Spryker/Yves/StepEngine/Dependency/DataContainer/DataContainerInterface.php
+++ b/src/Spryker/Yves/StepEngine/Dependency/DataContainer/DataContainerInterface.php
@@ -12,14 +12,14 @@ use Spryker\Shared\Kernel\Transfer\AbstractTransfer;
 interface DataContainerInterface
 {
     /**
-     * @return \Generated\Shared\Transfer\QuoteTransfer
+     * @return \Spryker\Shared\Kernel\Transfer\AbstractTransfer
      */
     public function get();
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return void
      */
-    public function set(AbstractTransfer $quoteTransfer);
+    public function set(AbstractTransfer $abstractTransfer);
 }

--- a/src/Spryker/Yves/StepEngine/Dependency/Form/StepEngineFormDataProviderInterface.php
+++ b/src/Spryker/Yves/StepEngine/Dependency/Form/StepEngineFormDataProviderInterface.php
@@ -12,16 +12,16 @@ use Spryker\Shared\Kernel\Transfer\AbstractTransfer;
 interface StepEngineFormDataProviderInterface
 {
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
-     * @return \Generated\Shared\Transfer\QuoteTransfer
+     * @return \Spryker\Shared\Kernel\Transfer\AbstractTransfer
      */
-    public function getData(AbstractTransfer $quoteTransfer);
+    public function getData(AbstractTransfer $abstractTransfer);
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return array<string, mixed>
      */
-    public function getOptions(AbstractTransfer $quoteTransfer);
+    public function getOptions(AbstractTransfer $abstractTransfer);
 }

--- a/src/Spryker/Yves/StepEngine/Dependency/Plugin/Handler/StepHandlerPluginInterface.php
+++ b/src/Spryker/Yves/StepEngine/Dependency/Plugin/Handler/StepHandlerPluginInterface.php
@@ -19,9 +19,9 @@ interface StepHandlerPluginInterface
      * @api
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
-     * @return \Generated\Shared\Transfer\QuoteTransfer
+     * @return \Spryker\Shared\Kernel\Transfer\AbstractTransfer
      */
-    public function addToDataClass(Request $request, AbstractTransfer $quoteTransfer);
+    public function addToDataClass(Request $request, AbstractTransfer $abstractTransfer);
 }

--- a/src/Spryker/Yves/StepEngine/Dependency/Plugin/Handler/StepHandlerPluginWithMessengerInterface.php
+++ b/src/Spryker/Yves/StepEngine/Dependency/Plugin/Handler/StepHandlerPluginWithMessengerInterface.php
@@ -20,11 +20,11 @@ interface StepHandlerPluginWithMessengerInterface extends StepHandlerPluginInter
      * @api
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
-     * @return \Generated\Shared\Transfer\QuoteTransfer
+     * @return \Spryker\Shared\Kernel\Transfer\AbstractTransfer
      */
-    public function addToDataClass(Request $request, AbstractTransfer $quoteTransfer);
+    public function addToDataClass(Request $request, AbstractTransfer $abstractTransfer);
 
     /**
      * Specification:

--- a/src/Spryker/Yves/StepEngine/Dependency/Step/AbstractBaseStep.php
+++ b/src/Spryker/Yves/StepEngine/Dependency/Step/AbstractBaseStep.php
@@ -48,11 +48,11 @@ abstract class AbstractBaseStep implements StepInterface
     }
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return array
      */
-    public function getTemplateVariables(AbstractTransfer $quoteTransfer)
+    public function getTemplateVariables(AbstractTransfer $abstractTransfer)
     {
         return [];
     }

--- a/src/Spryker/Yves/StepEngine/Dependency/Step/StepInterface.php
+++ b/src/Spryker/Yves/StepEngine/Dependency/Step/StepInterface.php
@@ -15,39 +15,39 @@ interface StepInterface
     /**
      * Requirements for this step, return true when satisfied.
      *
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return bool
      */
-    public function preCondition(AbstractTransfer $quoteTransfer);
+    public function preCondition(AbstractTransfer $abstractTransfer);
 
     /**
      * Require input, should we render view with form or just skip step after calling execute.
      *
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return bool
      */
-    public function requireInput(AbstractTransfer $quoteTransfer);
+    public function requireInput(AbstractTransfer $abstractTransfer);
 
     /**
      * Execute step logic, happens after form submit if provided, gets AbstractTransfer filled by form data.
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
-     * @return \Generated\Shared\Transfer\QuoteTransfer
+     * @return \Spryker\Shared\Kernel\Transfer\AbstractTransfer
      */
-    public function execute(Request $request, AbstractTransfer $quoteTransfer);
+    public function execute(Request $request, AbstractTransfer $abstractTransfer);
 
     /**
      * Conditions that should be met for this step to be marked as completed. returns true when satisfied.
      *
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return bool
      */
-    public function postCondition(AbstractTransfer $quoteTransfer);
+    public function postCondition(AbstractTransfer $abstractTransfer);
 
     /**
      * Current step route.
@@ -64,9 +64,9 @@ interface StepInterface
     public function getEscapeRoute();
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return array
      */
-    public function getTemplateVariables(AbstractTransfer $quoteTransfer);
+    public function getTemplateVariables(AbstractTransfer $abstractTransfer);
 }

--- a/src/Spryker/Yves/StepEngine/Dependency/Step/StepWithBreadcrumbInterface.php
+++ b/src/Spryker/Yves/StepEngine/Dependency/Step/StepWithBreadcrumbInterface.php
@@ -17,16 +17,16 @@ interface StepWithBreadcrumbInterface extends StepInterface
     public function getBreadcrumbItemTitle();
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return bool
      */
-    public function isBreadcrumbItemEnabled(AbstractTransfer $quoteTransfer);
+    public function isBreadcrumbItemEnabled(AbstractTransfer $abstractTransfer);
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return bool
      */
-    public function isBreadcrumbItemHidden(AbstractTransfer $quoteTransfer);
+    public function isBreadcrumbItemHidden(AbstractTransfer $abstractTransfer);
 }

--- a/src/Spryker/Yves/StepEngine/Form/FormCollectionHandler.php
+++ b/src/Spryker/Yves/StepEngine/Form/FormCollectionHandler.php
@@ -52,14 +52,14 @@ class FormCollectionHandler implements FormCollectionHandlerInterface
     }
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return array<\Symfony\Component\Form\FormInterface>
      */
-    public function getForms(AbstractTransfer $quoteTransfer)
+    public function getForms(AbstractTransfer $abstractTransfer)
     {
         if (!$this->forms) {
-            $this->forms = $this->createForms($quoteTransfer);
+            $this->forms = $this->createForms($abstractTransfer);
         }
 
         return $this->forms;
@@ -67,13 +67,13 @@ class FormCollectionHandler implements FormCollectionHandlerInterface
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return bool
      */
-    public function hasSubmittedForm(Request $request, AbstractTransfer $quoteTransfer)
+    public function hasSubmittedForm(Request $request, AbstractTransfer $abstractTransfer)
     {
-        foreach ($this->getForms($quoteTransfer) as $form) {
+        foreach ($this->getForms($abstractTransfer) as $form) {
             if ($request->request->has($form->getName())) {
                 return true;
             }
@@ -84,17 +84,17 @@ class FormCollectionHandler implements FormCollectionHandlerInterface
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @throws \Spryker\Yves\StepEngine\Exception\InvalidFormHandleRequest
      *
      * @return \Symfony\Component\Form\FormInterface
      */
-    public function handleRequest(Request $request, AbstractTransfer $quoteTransfer)
+    public function handleRequest(Request $request, AbstractTransfer $abstractTransfer)
     {
-        foreach ($this->getForms($quoteTransfer) as $form) {
+        foreach ($this->getForms($abstractTransfer) as $form) {
             if ($request->request->has($form->getName())) {
-                $form->setData($quoteTransfer);
+                $form->setData($abstractTransfer);
 
                 return $form->handleRequest($request);
             }
@@ -104,43 +104,43 @@ class FormCollectionHandler implements FormCollectionHandlerInterface
     }
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return void
      */
-    public function provideDefaultFormData(AbstractTransfer $quoteTransfer)
+    public function provideDefaultFormData(AbstractTransfer $abstractTransfer)
     {
-        $quoteTransfer = $this->getFormData($quoteTransfer);
+        $abstractTransfer = $this->getFormData($abstractTransfer);
 
-        foreach ($this->getForms($quoteTransfer) as $form) {
-            $form->setData($quoteTransfer);
+        foreach ($this->getForms($abstractTransfer) as $form) {
+            $form->setData($abstractTransfer);
         }
     }
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
-     * @return \Generated\Shared\Transfer\QuoteTransfer
+     * @return \Spryker\Shared\Kernel\Transfer\AbstractTransfer
      */
-    protected function getFormData(AbstractTransfer $quoteTransfer)
+    protected function getFormData(AbstractTransfer $abstractTransfer)
     {
         if ($this->dataProvider !== null) {
-            return $this->dataProvider->getData($quoteTransfer);
+            return $this->dataProvider->getData($abstractTransfer);
         }
 
-        return $quoteTransfer;
+        return $abstractTransfer;
     }
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return array<\Symfony\Component\Form\FormInterface>
      */
-    protected function createForms(AbstractTransfer $quoteTransfer)
+    protected function createForms(AbstractTransfer $abstractTransfer)
     {
         $forms = [];
         foreach ($this->formTypes as $formType) {
-            $forms[] = $this->createForm($formType, $quoteTransfer);
+            $forms[] = $this->createForm($formType, $abstractTransfer);
         }
 
         return $forms;
@@ -148,18 +148,18 @@ class FormCollectionHandler implements FormCollectionHandlerInterface
 
     /**
      * @param \Symfony\Component\Form\FormTypeInterface|string $formType
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return \Symfony\Component\Form\FormInterface
      */
-    protected function createForm($formType, AbstractTransfer $quoteTransfer)
+    protected function createForm($formType, AbstractTransfer $abstractTransfer)
     {
         $formOptions = [
-            'data_class' => get_class($quoteTransfer),
+            'data_class' => get_class($abstractTransfer),
         ];
 
         if ($this->dataProvider) {
-            $formOptions = array_merge($formOptions, $this->dataProvider->getOptions($quoteTransfer));
+            $formOptions = array_merge($formOptions, $this->dataProvider->getOptions($abstractTransfer));
         }
 
         if ($formType instanceof FormInterface) {

--- a/src/Spryker/Yves/StepEngine/Form/FormCollectionHandlerInterface.php
+++ b/src/Spryker/Yves/StepEngine/Form/FormCollectionHandlerInterface.php
@@ -13,32 +13,32 @@ use Symfony\Component\HttpFoundation\Request;
 interface FormCollectionHandlerInterface
 {
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return array<\Symfony\Component\Form\FormInterface>
      */
-    public function getForms(AbstractTransfer $quoteTransfer);
+    public function getForms(AbstractTransfer $abstractTransfer);
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return bool
      */
-    public function hasSubmittedForm(Request $request, AbstractTransfer $quoteTransfer);
+    public function hasSubmittedForm(Request $request, AbstractTransfer $abstractTransfer);
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return \Symfony\Component\Form\FormInterface|null
      */
-    public function handleRequest(Request $request, AbstractTransfer $quoteTransfer);
+    public function handleRequest(Request $request, AbstractTransfer $abstractTransfer);
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return void
      */
-    public function provideDefaultFormData(AbstractTransfer $quoteTransfer);
+    public function provideDefaultFormData(AbstractTransfer $abstractTransfer);
 }

--- a/src/Spryker/Yves/StepEngine/Process/StepBreadcrumbGenerator.php
+++ b/src/Spryker/Yves/StepEngine/Process/StepBreadcrumbGenerator.php
@@ -17,7 +17,7 @@ class StepBreadcrumbGenerator implements StepBreadcrumbGeneratorInterface
 {
     /**
      * @param \Spryker\Yves\StepEngine\Process\StepCollectionInterface $stepCollection
-     * @param \Generated\Shared\Transfer\QuoteTransfer|null $dataTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer|null $dataTransfer
      * @param \Spryker\Yves\StepEngine\Dependency\Step\StepInterface|null $currentStep
      *
      * @return \Generated\Shared\Transfer\StepBreadcrumbsTransfer
@@ -39,7 +39,7 @@ class StepBreadcrumbGenerator implements StepBreadcrumbGeneratorInterface
 
     /**
      * @param \Spryker\Yves\StepEngine\Process\StepCollectionInterface $stepCollection
-     * @param \Generated\Shared\Transfer\QuoteTransfer|null $dataTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer|null $dataTransfer
      *
      * @return array<\Spryker\Yves\StepEngine\Dependency\Step\StepWithBreadcrumbInterface>
      */
@@ -72,7 +72,7 @@ class StepBreadcrumbGenerator implements StepBreadcrumbGeneratorInterface
 
     /**
      * @param \Spryker\Yves\StepEngine\Dependency\Step\StepWithBreadcrumbInterface $stepWithBreadcrumb
-     * @param \Generated\Shared\Transfer\QuoteTransfer|null $dataTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer|null $dataTransfer
      *
      * @return bool
      */
@@ -98,7 +98,7 @@ class StepBreadcrumbGenerator implements StepBreadcrumbGeneratorInterface
 
     /**
      * @param \Spryker\Yves\StepEngine\Dependency\Step\StepWithBreadcrumbInterface $stepWithBreadcrumb
-     * @param \Generated\Shared\Transfer\QuoteTransfer|null $dataTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer|null $dataTransfer
      *
      * @return bool
      */

--- a/src/Spryker/Yves/StepEngine/Process/StepBreadcrumbGeneratorInterface.php
+++ b/src/Spryker/Yves/StepEngine/Process/StepBreadcrumbGeneratorInterface.php
@@ -14,7 +14,7 @@ interface StepBreadcrumbGeneratorInterface
 {
     /**
      * @param \Spryker\Yves\StepEngine\Process\StepCollectionInterface $stepCollection
-     * @param \Generated\Shared\Transfer\QuoteTransfer|null $dataTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer|null $dataTransfer
      * @param \Spryker\Yves\StepEngine\Dependency\Step\StepInterface|null $currentStep
      *
      * @return \Generated\Shared\Transfer\StepBreadcrumbsTransfer

--- a/src/Spryker/Yves/StepEngine/Process/StepCollection.php
+++ b/src/Spryker/Yves/StepEngine/Process/StepCollection.php
@@ -62,17 +62,17 @@ class StepCollection implements StepCollectionInterface
     /**
      * @param \Spryker\Yves\StepEngine\Dependency\Step\StepInterface $step
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return bool
      */
-    public function canAccessStep(StepInterface $step, Request $request, AbstractTransfer $quoteTransfer)
+    public function canAccessStep(StepInterface $step, Request $request, AbstractTransfer $abstractTransfer)
     {
         if ($request->get('_route') === $step->getStepRoute()) {
             return true;
         }
 
-        foreach ($this->getCompletedSteps($quoteTransfer) as $completedStep) {
+        foreach ($this->getCompletedSteps($abstractTransfer) as $completedStep) {
             if ($completedStep->getStepRoute() === $request->get('_route')) {
                 return true;
             }
@@ -82,15 +82,15 @@ class StepCollection implements StepCollectionInterface
     }
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return array<\Spryker\Yves\StepEngine\Dependency\Step\StepInterface>
      */
-    protected function getCompletedSteps(AbstractTransfer $quoteTransfer)
+    protected function getCompletedSteps(AbstractTransfer $abstractTransfer)
     {
         $completedSteps = [];
         foreach ($this->steps as $step) {
-            if ($step->postCondition($quoteTransfer)) {
+            if ($step->postCondition($abstractTransfer)) {
                 $completedSteps[] = $step;
             }
         }
@@ -100,14 +100,14 @@ class StepCollection implements StepCollectionInterface
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return \Spryker\Yves\StepEngine\Dependency\Step\StepInterface
      */
-    public function getCurrentStep(Request $request, AbstractTransfer $quoteTransfer)
+    public function getCurrentStep(Request $request, AbstractTransfer $abstractTransfer)
     {
         foreach ($this->steps as $step) {
-            if (!$step->postCondition($quoteTransfer) || $request->get('_route') === $step->getStepRoute()) {
+            if (!$step->postCondition($abstractTransfer) || $request->get('_route') === $step->getStepRoute()) {
                 return $step;
             }
 
@@ -142,7 +142,7 @@ class StepCollection implements StepCollectionInterface
 
     /**
      * @param \Spryker\Yves\StepEngine\Dependency\Step\StepInterface $currentStep
-     * @param \Generated\Shared\Transfer\QuoteTransfer|null $dataTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer|null $dataTransfer
      *
      * @return \Spryker\Yves\StepEngine\Dependency\Step\StepInterface
      */
@@ -172,7 +172,7 @@ class StepCollection implements StepCollectionInterface
 
     /**
      * @param \Spryker\Yves\StepEngine\Dependency\Step\StepInterface $step
-     * @param \Generated\Shared\Transfer\QuoteTransfer|null $dataTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer|null $dataTransfer
      *
      * @return bool
      */
@@ -197,30 +197,30 @@ class StepCollection implements StepCollectionInterface
 
     /**
      * @param \Spryker\Yves\StepEngine\Dependency\Step\StepInterface $currentStep
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return string
      */
-    public function getNextUrl(StepInterface $currentStep, AbstractTransfer $quoteTransfer)
+    public function getNextUrl(StepInterface $currentStep, AbstractTransfer $abstractTransfer)
     {
         if (($currentStep instanceof StepWithExternalRedirectInterface) && $currentStep->getExternalRedirectUrl()) {
             return $currentStep->getExternalRedirectUrl();
         }
 
-        $route = $this->getNextStepRoute($currentStep, $quoteTransfer);
+        $route = $this->getNextStepRoute($currentStep, $abstractTransfer);
 
         return $this->getUrlFromRoute($route);
     }
 
     /**
      * @param \Spryker\Yves\StepEngine\Dependency\Step\StepInterface $currentStep
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return string
      */
-    protected function getNextStepRoute(StepInterface $currentStep, AbstractTransfer $quoteTransfer)
+    protected function getNextStepRoute(StepInterface $currentStep, AbstractTransfer $abstractTransfer)
     {
-        if ($currentStep->postCondition($quoteTransfer)) {
+        if ($currentStep->postCondition($abstractTransfer)) {
             $nextStep = $this->getNextStep($currentStep);
 
             return $nextStep->getStepRoute();
@@ -230,7 +230,7 @@ class StepCollection implements StepCollectionInterface
             return $currentStep->getPostConditionErrorRoute();
         }
 
-        if ($currentStep->requireInput($quoteTransfer)) {
+        if ($currentStep->requireInput($abstractTransfer)) {
             return $currentStep->getStepRoute();
         }
 
@@ -239,13 +239,13 @@ class StepCollection implements StepCollectionInterface
 
     /**
      * @param \Spryker\Yves\StepEngine\Dependency\Step\StepInterface $currentStep
-     * @param \Generated\Shared\Transfer\QuoteTransfer|null $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer|null $abstractTransfer
      *
      * @return string
      */
-    public function getPreviousUrl(StepInterface $currentStep, ?AbstractTransfer $quoteTransfer = null)
+    public function getPreviousUrl(StepInterface $currentStep, ?AbstractTransfer $abstractTransfer = null)
     {
-        $stepRoute = $this->getPreviousStep($currentStep, $quoteTransfer)->getStepRoute();
+        $stepRoute = $this->getPreviousStep($currentStep, $abstractTransfer)->getStepRoute();
 
         return $this->getUrlFromRoute($stepRoute);
     }

--- a/src/Spryker/Yves/StepEngine/Process/StepCollectionInterface.php
+++ b/src/Spryker/Yves/StepEngine/Process/StepCollectionInterface.php
@@ -27,19 +27,19 @@ interface StepCollectionInterface extends IteratorAggregate
     /**
      * @param \Spryker\Yves\StepEngine\Dependency\Step\StepInterface $step
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return bool
      */
-    public function canAccessStep(StepInterface $step, Request $request, AbstractTransfer $quoteTransfer);
+    public function canAccessStep(StepInterface $step, Request $request, AbstractTransfer $abstractTransfer);
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return \Spryker\Yves\StepEngine\Dependency\Step\StepInterface
      */
-    public function getCurrentStep(Request $request, AbstractTransfer $quoteTransfer);
+    public function getCurrentStep(Request $request, AbstractTransfer $abstractTransfer);
 
     /**
      * @param \Spryker\Yves\StepEngine\Dependency\Step\StepInterface $currentStep
@@ -50,7 +50,7 @@ interface StepCollectionInterface extends IteratorAggregate
 
     /**
      * @param \Spryker\Yves\StepEngine\Dependency\Step\StepInterface $currentStep
-     * @param \Generated\Shared\Transfer\QuoteTransfer|null $dataTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer|null $dataTransfer
      *
      * @return \Spryker\Yves\StepEngine\Dependency\Step\StepInterface
      */
@@ -65,19 +65,19 @@ interface StepCollectionInterface extends IteratorAggregate
 
     /**
      * @param \Spryker\Yves\StepEngine\Dependency\Step\StepInterface $currentStep
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return string
      */
-    public function getNextUrl(StepInterface $currentStep, AbstractTransfer $quoteTransfer);
+    public function getNextUrl(StepInterface $currentStep, AbstractTransfer $abstractTransfer);
 
     /**
      * @param \Spryker\Yves\StepEngine\Dependency\Step\StepInterface $currentStep
-     * @param \Generated\Shared\Transfer\QuoteTransfer|null $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer|null $abstractTransfer
      *
      * @return string
      */
-    public function getPreviousUrl(StepInterface $currentStep, ?AbstractTransfer $quoteTransfer = null);
+    public function getPreviousUrl(StepInterface $currentStep, ?AbstractTransfer $abstractTransfer = null);
 
     /**
      * @param \Spryker\Yves\StepEngine\Dependency\Step\StepInterface $currentStep

--- a/src/Spryker/Yves/StepEngine/Process/StepEngine.php
+++ b/src/Spryker/Yves/StepEngine/Process/StepEngine.php
@@ -80,53 +80,53 @@ class StepEngine implements StepEngineInterface
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      * @param \Spryker\Yves\StepEngine\Form\FormCollectionHandlerInterface|null $formCollection
      *
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|array
      */
-    protected function runProcess(Request $request, AbstractTransfer $quoteTransfer, ?FormCollectionHandlerInterface $formCollection = null)
+    protected function runProcess(Request $request, AbstractTransfer $abstractTransfer, ?FormCollectionHandlerInterface $formCollection = null)
     {
-        $currentStep = $this->stepCollection->getCurrentStep($request, $quoteTransfer);
+        $currentStep = $this->stepCollection->getCurrentStep($request, $abstractTransfer);
 
-        if (!$currentStep->preCondition($quoteTransfer)) {
+        if (!$currentStep->preCondition($abstractTransfer)) {
             return $this->createRedirectResponse($this->stepCollection->getEscapeUrl($currentStep));
         }
 
-        if (!$this->stepCollection->canAccessStep($currentStep, $request, $quoteTransfer)) {
+        if (!$this->stepCollection->canAccessStep($currentStep, $request, $abstractTransfer)) {
             return $this->createRedirectResponse($this->stepCollection->getCurrentUrl($currentStep));
         }
 
-        if (!$currentStep->requireInput($quoteTransfer)) {
-            $quoteTransfer = $this->executeWithoutInput($currentStep, $request, $quoteTransfer);
+        if (!$currentStep->requireInput($abstractTransfer)) {
+            $abstractTransfer = $this->executeWithoutInput($currentStep, $request, $abstractTransfer);
 
-            return $this->createRedirectResponse($this->stepCollection->getNextUrl($currentStep, $quoteTransfer));
+            return $this->createRedirectResponse($this->stepCollection->getNextUrl($currentStep, $abstractTransfer));
         }
         if (!$this->isRequestedStep($request, $currentStep)) {
             return $this->createRedirectResponse($this->stepCollection->getCurrentUrl($currentStep));
         }
 
-        $quoteTransfer = $this->executeStepEnginePreRenderPlugins($quoteTransfer);
+        $abstractTransfer = $this->executeStepEnginePreRenderPlugins($abstractTransfer);
 
         if (!$formCollection) {
-            $quoteTransfer = $this->executeWithoutInput($currentStep, $request, $quoteTransfer);
+            $abstractTransfer = $this->executeWithoutInput($currentStep, $request, $abstractTransfer);
 
-            return $this->getTemplateVariables($currentStep, $quoteTransfer);
+            return $this->getTemplateVariables($currentStep, $abstractTransfer);
         }
 
-        if ($formCollection->hasSubmittedForm($request, $quoteTransfer)) {
+        if ($formCollection->hasSubmittedForm($request, $abstractTransfer)) {
             /** @var \Symfony\Component\Form\FormInterface $form */
-            $form = $formCollection->handleRequest($request, $quoteTransfer);
+            $form = $formCollection->handleRequest($request, $abstractTransfer);
             if ($form->isSubmitted() && $form->isValid()) {
-                $quoteTransfer = $this->executeWithFormInput($currentStep, $request, $quoteTransfer, $form->getData());
+                $abstractTransfer = $this->executeWithFormInput($currentStep, $request, $abstractTransfer, $form->getData());
 
-                return $this->createRedirectResponse($this->stepCollection->getNextUrl($currentStep, $quoteTransfer));
+                return $this->createRedirectResponse($this->stepCollection->getNextUrl($currentStep, $abstractTransfer));
             }
         } else {
-            $formCollection->provideDefaultFormData($quoteTransfer);
+            $formCollection->provideDefaultFormData($abstractTransfer);
         }
 
-        return $this->getTemplateVariables($currentStep, $quoteTransfer, $formCollection);
+        return $this->getTemplateVariables($currentStep, $abstractTransfer, $formCollection);
     }
 
     /**
@@ -143,39 +143,39 @@ class StepEngine implements StepEngineInterface
     /**
      * @param \Spryker\Yves\StepEngine\Dependency\Step\StepInterface $currentStep
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
-     * @return \Generated\Shared\Transfer\QuoteTransfer
+     * @return \Spryker\Shared\Kernel\Transfer\AbstractTransfer
      */
-    protected function executeWithoutInput(StepInterface $currentStep, Request $request, AbstractTransfer $quoteTransfer)
+    protected function executeWithoutInput(StepInterface $currentStep, Request $request, AbstractTransfer $abstractTransfer)
     {
-        $quoteTransfer = $currentStep->execute($request, $quoteTransfer);
+        $abstractTransfer = $currentStep->execute($request, $abstractTransfer);
 
-        $this->dataContainer->set($quoteTransfer);
+        $this->dataContainer->set($abstractTransfer);
 
-        return $quoteTransfer;
+        return $abstractTransfer;
     }
 
     /**
      * @param \Spryker\Yves\StepEngine\Dependency\Step\StepInterface $currentStep
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
-     * @param \Generated\Shared\Transfer\QuoteTransfer $formTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $formTransfer
      *
-     * @return \Generated\Shared\Transfer\QuoteTransfer
+     * @return \Spryker\Shared\Kernel\Transfer\AbstractTransfer
      */
     protected function executeWithFormInput(
         StepInterface $currentStep,
         Request $request,
-        AbstractTransfer $quoteTransfer,
+        AbstractTransfer $abstractTransfer,
         AbstractTransfer $formTransfer
     ) {
-        $quoteTransfer->fromArray($formTransfer->modifiedToArray());
-        $quoteTransfer = $currentStep->execute($request, $formTransfer);
+        $abstractTransfer->fromArray($formTransfer->modifiedToArray());
+        $abstractTransfer = $currentStep->execute($request, $formTransfer);
 
-        $this->dataContainer->set($quoteTransfer);
+        $this->dataContainer->set($abstractTransfer);
 
-        return $quoteTransfer;
+        return $abstractTransfer;
     }
 
     /**
@@ -190,27 +190,27 @@ class StepEngine implements StepEngineInterface
 
     /**
      * @param \Spryker\Yves\StepEngine\Dependency\Step\StepInterface $currentStep
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      * @param \Spryker\Yves\StepEngine\Form\FormCollectionHandlerInterface|null $formCollection
      *
      * @return array
      */
-    protected function getTemplateVariables(StepInterface $currentStep, AbstractTransfer $quoteTransfer, ?FormCollectionHandlerInterface $formCollection = null)
+    protected function getTemplateVariables(StepInterface $currentStep, AbstractTransfer $abstractTransfer, ?FormCollectionHandlerInterface $formCollection = null)
     {
         $templateVariables = [];
 
-        $templateVariables[static::TEMPLATE_VARIABLE_PREVIOUS_STEP_URL] = $this->stepCollection->getPreviousUrl($currentStep, $quoteTransfer);
+        $templateVariables[static::TEMPLATE_VARIABLE_PREVIOUS_STEP_URL] = $this->stepCollection->getPreviousUrl($currentStep, $abstractTransfer);
         if ($this->stepBreadcrumbGenerator) {
             $templateVariables[static::TEMPLATE_VARIABLE_STEP_BREADCRUMBS] = $this->stepBreadcrumbGenerator->generateStepBreadcrumbs(
                 $this->stepCollection,
-                $quoteTransfer,
+                $abstractTransfer,
                 $currentStep,
             );
         }
-        $templateVariables = array_merge($templateVariables, $currentStep->getTemplateVariables($quoteTransfer));
+        $templateVariables = array_merge($templateVariables, $currentStep->getTemplateVariables($abstractTransfer));
 
         if ($formCollection !== null) {
-            foreach ($formCollection->getForms($quoteTransfer) as $form) {
+            foreach ($formCollection->getForms($abstractTransfer) as $form) {
                 $templateVariables[$form->getName()] = $form->createView();
             }
         }
@@ -219,16 +219,16 @@ class StepEngine implements StepEngineInterface
     }
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
-     * @return \Generated\Shared\Transfer\QuoteTransfer
+     * @return \Spryker\Shared\Kernel\Transfer\AbstractTransfer
      */
-    protected function executeStepEnginePreRenderPlugins(AbstractTransfer $quoteTransfer): AbstractTransfer
+    protected function executeStepEnginePreRenderPlugins(AbstractTransfer $abstractTransfer): AbstractTransfer
     {
         foreach ($this->stepEnginePreRenderPlugins as $stepEnginePreRenderPlugin) {
-            $quoteTransfer = $stepEnginePreRenderPlugin->execute($quoteTransfer);
+            $abstractTransfer = $stepEnginePreRenderPlugin->execute($abstractTransfer);
         }
 
-        return $quoteTransfer;
+        return $abstractTransfer;
     }
 }

--- a/tests/SprykerTest/Yves/StepEngine/Dependency/Step/Fixtures/BaseStep.php
+++ b/tests/SprykerTest/Yves/StepEngine/Dependency/Step/Fixtures/BaseStep.php
@@ -14,41 +14,41 @@ use Symfony\Component\HttpFoundation\Request;
 class BaseStep extends AbstractBaseStep
 {
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return bool
      */
-    public function preCondition(AbstractTransfer $quoteTransfer): bool
+    public function preCondition(AbstractTransfer $abstractTransfer): bool
     {
         return true;
     }
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return bool
      */
-    public function requireInput(AbstractTransfer $quoteTransfer): bool
+    public function requireInput(AbstractTransfer $abstractTransfer): bool
     {
         return true;
     }
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return void
      */
-    public function execute(Request $request, AbstractTransfer $quoteTransfer): void
+    public function execute(Request $request, AbstractTransfer $abstractTransfer): void
     {
     }
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return bool
      */
-    public function postCondition(AbstractTransfer $quoteTransfer): bool
+    public function postCondition(AbstractTransfer $abstractTransfer): bool
     {
         return true;
     }

--- a/tests/SprykerTest/Yves/StepEngine/Process/Fixtures/StepMock.php
+++ b/tests/SprykerTest/Yves/StepEngine/Process/Fixtures/StepMock.php
@@ -60,42 +60,42 @@ class StepMock implements StepInterface
     }
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return bool
      */
-    public function preCondition(AbstractTransfer $quoteTransfer): bool
+    public function preCondition(AbstractTransfer $abstractTransfer): bool
     {
         return $this->preCondition;
     }
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return bool
      */
-    public function requireInput(AbstractTransfer $quoteTransfer): bool
+    public function requireInput(AbstractTransfer $abstractTransfer): bool
     {
         return $this->requireInput;
     }
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return \Spryker\Shared\Kernel\Transfer\AbstractTransfer
      */
-    public function execute(Request $request, AbstractTransfer $quoteTransfer): AbstractTransfer
+    public function execute(Request $request, AbstractTransfer $abstractTransfer): AbstractTransfer
     {
-        return $quoteTransfer;
+        return $abstractTransfer;
     }
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return bool
      */
-    public function postCondition(AbstractTransfer $quoteTransfer): bool
+    public function postCondition(AbstractTransfer $abstractTransfer): bool
     {
         return $this->postCondition;
     }
@@ -117,11 +117,11 @@ class StepMock implements StepInterface
     }
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return array
      */
-    public function getTemplateVariables(AbstractTransfer $quoteTransfer): array
+    public function getTemplateVariables(AbstractTransfer $abstractTransfer): array
     {
         return [];
     }

--- a/tests/SprykerTest/Yves/StepEngine/Process/Fixtures/StepMockWithBreadcrumbs.php
+++ b/tests/SprykerTest/Yves/StepEngine/Process/Fixtures/StepMockWithBreadcrumbs.php
@@ -21,22 +21,22 @@ class StepMockWithBreadcrumbs extends StepMock implements StepWithBreadcrumbInte
     }
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return bool
      */
-    public function isBreadcrumbItemEnabled(AbstractTransfer $quoteTransfer): bool
+    public function isBreadcrumbItemEnabled(AbstractTransfer $abstractTransfer): bool
     {
-        return $this->postCondition($quoteTransfer);
+        return $this->postCondition($abstractTransfer);
     }
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer $abstractTransfer
      *
      * @return bool
      */
-    public function isBreadcrumbItemHidden(AbstractTransfer $quoteTransfer): bool
+    public function isBreadcrumbItemHidden(AbstractTransfer $abstractTransfer): bool
     {
-        return !$this->requireInput($quoteTransfer);
+        return !$this->requireInput($abstractTransfer);
     }
 }

--- a/tests/SprykerTest/Yves/StepEngine/Process/StepEngineTest.php
+++ b/tests/SprykerTest/Yves/StepEngine/Process/StepEngineTest.php
@@ -183,7 +183,7 @@ class StepEngineTest extends AbstractStepEngineTest
     }
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer|null $dataTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer|null $dataTransfer
      *
      * @return \PHPUnit\Framework\MockObject\MockObject|\Spryker\Yves\StepEngine\Dependency\DataContainer\DataContainerInterface
      */

--- a/tests/SprykerTest/Yves/StepEngine/Process/StepEngineWithBreadcrumbsTest.php
+++ b/tests/SprykerTest/Yves/StepEngine/Process/StepEngineWithBreadcrumbsTest.php
@@ -55,7 +55,7 @@ class StepEngineWithBreadcrumbsTest extends AbstractStepEngineTest
     }
 
     /**
-     * @param \Generated\Shared\Transfer\QuoteTransfer|null $dataTransfer
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer|null $dataTransfer
      *
      * @return \PHPUnit\Framework\MockObject\MockObject|\Spryker\Yves\StepEngine\Dependency\DataContainer\DataContainerInterface
      */


### PR DESCRIPTION
## PR Description
AbstractTransfers are used in the spryker/step-engine package, which are a $quoteTransfer according to the annotation and variable name. This leads to misunderstandings and links the step engine to the checkout. However, as the step engine can also be used for other multi-step forms (wizards) independently of the checkout, it should not be linked to the checkout in the wording.

## Steps before you submit a PR
- Please add tests for the code you add if it's possible.
- Please check out our contribution guide: https://docs.spryker.com/docs/dg/dev/code-contribution-guide.html
- Add a `contribution-license-agreement.txt` file with the following content:
`I hereby agree to Spryker\'s Contribution License Agreement in https://github.com/spryker/step-engine/blob/HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH/CONTRIBUTING.md.`

This is a mandatory step to make sure you are aware of the license agreement and agree to it. `HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH` is a hash of the commit you are basing your branch from the master branch. You can take it from commits list of master branch before you submit a PR.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
